### PR TITLE
Add logistic regression model for sentiment prediction

### DIFF
--- a/trump_prediction_sentiment.ipynb
+++ b/trump_prediction_sentiment.ipynb
@@ -1,342 +1,101 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "gpuType": "T4",
-      "authorship_tag": "ABX9TyNjL1UCRvb7ehHlHE2wfebd",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "gpuType": "T4",
+   "authorship_tag": "ABX9TyNjL1UCRvb7ehHlHE2wfebd",
+   "include_colab_link": true
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/wiktorialasek/Thesis/blob/main/trump_prediction_sentiment.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "id": "TAUnt360QYgB"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "import numpy as np\n",
-        "import requests\n",
-        "import zipfile\n",
-        "import io\n",
-        "import csv\n",
-        "import os\n",
-        "from datetime import timedelta\n",
-        "from sklearn.model_selection import train_test_split\n",
-        "from sklearn.feature_extraction.text import TfidfVectorizer\n",
-        "from sklearn.linear_model import LogisticRegression\n",
-        "from sklearn.metrics import accuracy_score, precision_score, recall_score, confusion_matrix\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Załaduj dane z pliku CSV z dokładnie określonymi nazwami kolumn\n",
-        "tweets = pd.read_csv(\n",
-        "    '/content/drive/MyDrive/tweets_TRUMP.csv',\n",
-        "    header=0, # Set header to 0 to use the first row as header\n",
-        "    names=[\n",
-        "        'tweet_id', 'text', 'isRetweet', 'isDeleted', 'device',\n",
-        "        'favorites', 'retweets', 'date', 'isFlagged'\n",
-        "    ],\n",
-        "    usecols=['text', 'date']\n",
-        ")\n",
-        "\n",
-        "# Konwersja kolumny 'date' do datetime w strefie UTC\n",
-        "tweets['date'] = pd.to_datetime(tweets['date'], utc=True)\n",
-        "\n",
-        "# Wyświetl 5 pierwszych rekordów dla sprawdzenia\n",
-        "print(tweets.head())"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "JBUHeSQdW0LU",
-        "outputId": "9f9dd1a8-cbed-4cf1-e4c8-00a9473359e0"
-      },
-      "execution_count": 32,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "                                                text                      date\n",
-            "0  Republicans and Democrats have both created ou... 2011-08-02 18:07:48+00:00\n",
-            "1  I was thrilled to be back in the Great city of... 2020-03-03 01:34:50+00:00\n",
-            "2  RT @CBS_Herridge: READ: Letter to surveillance... 2020-01-17 03:22:47+00:00\n",
-            "3  The Unsolicited Mail In Ballot Scam is a major... 2020-09-12 20:10:58+00:00\n",
-            "4  RT @MZHemingway: Very friendly telling of even... 2020-01-17 13:13:59+00:00\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# 2. Assign stock_label based on keywords\n",
-        "def assign_label(text):\n",
-        "    t = str(text).lower()\n",
-        "    if any(k in t for k in ['dollar', '$', 'usd', 'greenback']):\n",
-        "        return 'dollar'\n",
-        "    if any(k in t for k in ['euro', 'eur', '€']):\n",
-        "        return 'euro'\n",
-        "    if any(k in t for k in ['s&p', 's&p500', 'sp500', '^gspc']):\n",
-        "        return 'sp500'\n",
-        "    return None\n",
-        "\n",
-        "tweets['stock_label'] = tweets['text'].apply(assign_label)\n",
-        "tweets = tweets.dropna(subset=['stock_label'])"
-      ],
-      "metadata": {
-        "id": "eMZ5izvbWPqT"
-      },
-      "execution_count": 33,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# prompt: pokaz mi jak obecnie wyglada baza danych z dodana kolumna\n",
-        "\n",
-        "print(tweets.head())"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "XerAd5L-YDAr",
-        "outputId": "c3c3252c-d6d9-41f4-c32f-dae8d92fd9bf"
-      },
-      "execution_count": 34,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "                                                  text  \\\n",
-            "294  ...For years, I watched one betrayal after ano...   \n",
-            "328  RT @ArthurSchwartz: Texas Lt. Gov. Dan Patrick...   \n",
-            "371  European Countries are sadly getting clobbered...   \n",
-            "443  RT @DonaldJTrumpJr: 🚨🚨🚨Hunter Biden Offered $1...   \n",
-            "459  $13.9M is heading to New Orleans in @USDOT fun...   \n",
-            "\n",
-            "                         date stock_label  \n",
-            "294 2020-10-24 02:06:10+00:00      dollar  \n",
-            "328 2020-11-11 02:44:06+00:00      dollar  \n",
-            "371 2020-11-16 16:11:09+00:00        euro  \n",
-            "443 2020-10-16 04:37:02+00:00      dollar  \n",
-            "459 2020-08-12 18:43:05+00:00      dollar  \n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#Save to csv\n",
-        "output_csv_path = '/content/drive/MyDrive/labeled_tweets.csv'\n",
-        "tweets.to_csv(output_csv_path, index=False)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "FU4FmMinYT-t",
-        "outputId": "5ace693a-e173-42f3-b48b-d87e4701f17b"
-      },
-      "execution_count": 35,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Zapisano przetworzone tweety do /content/drive/MyDrive/labeled_tweets.csv\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# # 3. Download market data from GitHub\n",
-        "# base_url = 'https://github.com/philipperemy/FX-1-Minute-Data/raw/master'\n",
-        "# https://github.com/philipperemy/FX-1-Minute-Data.git\n",
-        "# zip_map = {\n",
-        "#     'euro': 'EURUSD.zip',\n",
-        "#     'dollar': 'USDOLLAR.zip',\n",
-        "#     'sp500': 'SPXUSD.zip',\n",
-        "# }\n",
-        "\n",
-        "# os.makedirs('market_data', exist_ok=True)\n",
-        "\n",
-        "# for label, zip_name in zip_map.items():\n",
-        "#     url = f\"{base_url}/{zip_name}\"\n",
-        "#     dest_path = os.path.join('market_data', zip_name)\n",
-        "#     if not os.path.exists(dest_path.replace('.zip', '.csv')):\n",
-        "#         r = requests.get(url)\n",
-        "#         z = zipfile.ZipFile(io.BytesIO(r.content))\n",
-        "#         z.extractall('market_data')\n",
-        "\n",
-        "# # Load market data as DataFrames\n",
-        "# data = {}\n",
-        "# for label, zip_name in zip_map.items():\n",
-        "#     csv_name = zip_name.replace('.zip', '.csv')\n",
-        "#     df = pd.read_csv(os.path.join('market_data', csv_name))\n",
-        "#     # guess date column name\n",
-        "#     if 'Date' in df.columns:\n",
-        "#         df['datetime'] = pd.to_datetime(df['Date'], utc=True)\n",
-        "#     elif 'date' in df.columns:\n",
-        "#         df['datetime'] = pd.to_datetime(df['date'], utc=True)\n",
-        "#     else:\n",
-        "#         df['datetime'] = pd.to_datetime(df.iloc[:,0], utc=True)\n",
-        "#     data[label] = df.sort_values('datetime')\n",
-        "\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 375
-        },
-        "id": "twbq83VvXkpm",
-        "outputId": "02c84d85-8dda-41e5-a6dd-d684963ff861"
-      },
-      "execution_count": 29,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "BadZipFile",
-          "evalue": "File is not a zip file",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mBadZipFile\u001b[0m                                Traceback (most recent call last)",
-            "\u001b[0;32m/tmp/ipython-input-29-326156176.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     14\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexists\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdest_path\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'.zip'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'.csv'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     15\u001b[0m         \u001b[0mr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrequests\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 16\u001b[0;31m         \u001b[0mz\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mzipfile\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mZipFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBytesIO\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     17\u001b[0m         \u001b[0mz\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextractall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'market_data'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/lib/python3.11/zipfile.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, file, mode, compression, allowZip64, compresslevel, strict_timestamps, metadata_encoding)\u001b[0m\n\u001b[1;32m   1311\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1312\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'r'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1313\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_RealGetContents\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1314\u001b[0m             \u001b[0;32melif\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m'w'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'x'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1315\u001b[0m                 \u001b[0;31m# set the modified flag so central directory gets written\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/lib/python3.11/zipfile.py\u001b[0m in \u001b[0;36m_RealGetContents\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1378\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mBadZipFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"File is not a zip file\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1379\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mendrec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1380\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mBadZipFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"File is not a zip file\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1381\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdebug\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1382\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mendrec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mBadZipFile\u001b[0m: File is not a zip file"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "\n",
-        "# # 4. Compute price changes\n",
-        "# def compute_changes(df, times):\n",
-        "#     df = df.sort_values('datetime')\n",
-        "#     results = {}\n",
-        "#     for col, t in times.items():\n",
-        "#         merged = pd.merge_asof(pd.DataFrame({'target': t}), df, left_on='target', right_on='datetime', direction='backward')\n",
-        "#         results[col] = merged['Close'].values\n",
-        "#     return results\n",
-        "\n",
-        "# intervals = {\n",
-        "#     'price_now': tweets['timestamp'],\n",
-        "#     'p_1min': tweets['timestamp'] + timedelta(minutes=1),\n",
-        "#     'p_5min': tweets['timestamp'] + timedelta(minutes=5),\n",
-        "#     'p_10min': tweets['timestamp'] + timedelta(minutes=10),\n",
-        "#     'p_1h': tweets['timestamp'] + timedelta(hours=1),\n",
-        "#     'p_1d': tweets['timestamp'] + timedelta(days=1),\n",
-        "# }\n",
-        "\n",
-        "# for label in ['euro', 'dollar', 'sp500']:\n",
-        "#     mask = tweets['stock_label'] == label\n",
-        "#     idx = mask[mask].index\n",
-        "#     if len(idx) == 0:\n",
-        "#         continue\n",
-        "#     subset = tweets.loc[idx]\n",
-        "#     res = compute_changes(data[label], {k:v.loc[idx] for k,v in intervals.items()})\n",
-        "#     for col, values in res.items():\n",
-        "#         tweets.loc[idx, col] = values\n",
-        "\n",
-        "# # next day open\n",
-        "# for label in ['euro', 'dollar', 'sp500']:\n",
-        "#     df = data[label]\n",
-        "#     df['date'] = df['datetime'].dt.date\n",
-        "#     open_prices = df.groupby('date')['Open'].first()\n",
-        "#     mask = tweets['stock_label'] == label\n",
-        "#     next_days = tweets.loc[mask, 'timestamp'].dt.date + pd.Timedelta(days=1)\n",
-        "#     tweets.loc[mask, 'p_next_open'] = open_prices.reindex(next_days).values\n",
-        "\n",
-        "# # 5. Percent changes\n",
-        "# tweets['change_1min'] = (tweets['p_1min'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "# tweets['change_5min'] = (tweets['p_5min'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "# tweets['change_10min'] = (tweets['p_10min'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "# tweets['change_1h'] = (tweets['p_1h'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "# tweets['change_1d'] = (tweets['p_1d'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "# tweets['change_next_open'] = (tweets['p_next_open'] - tweets['price_now']) / tweets['price_now'] * 100\n",
-        "\n",
-        "# # 6. Labeling\n",
-        "# max_change = tweets[['change_1min','change_5min','change_10min','change_1h','change_1d','change_next_open']].max(axis=1)\n",
-        "# min_change = tweets[['change_1min','change_5min','change_10min','change_1h','change_1d','change_next_open']].min(axis=1)\n",
-        "\n",
-        "# conditions = [max_change > 0.5, min_change < -0.5]\n",
-        "# choices = ['increase', 'decrease']\n",
-        "# tweets['label'] = np.select(conditions, choices, default='neutral')\n",
-        "\n",
-        "# # 7. Text classification model\n",
-        "# vectorizer = TfidfVectorizer(stop_words='english', max_features=5000)\n",
-        "# X = vectorizer.fit_transform(tweets['text'])\n",
-        "# y = tweets['label']\n",
-        "\n",
-        "# X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
-        "\n",
-        "# clf = LogisticRegression(max_iter=1000)\n",
-        "# clf.fit(X_train, y_train)\n",
-        "\n",
-        "# y_pred = clf.predict(X_test)\n",
-        "\n",
-        "# acc = accuracy_score(y_test, y_pred)\n",
-        "# prec = precision_score(y_test, y_pred, average='weighted')\n",
-        "# rec = recall_score(y_test, y_pred, average='weighted')\n",
-        "# cm = confusion_matrix(y_test, y_pred)\n",
-        "\n",
-        "# print('Accuracy:', acc)\n",
-        "# print('Precision:', prec)\n",
-        "# print('Recall:', rec)\n",
-        "# print('Confusion Matrix:\\n', cm)"
-      ],
-      "metadata": {
-        "id": "qE4Orjx4Xpab"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# # Save result\n",
-        "# tweets.to_csv('tweets_text_date.csv', index=False)"
-      ],
-      "metadata": {
-        "id": "JUxW1-mkQqQq"
-      },
-      "execution_count": 15,
-      "outputs": []
-    }
-  ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/wiktorialasek/Thesis/blob/main/trump_prediction_sentiment.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.metrics import classification_report\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "df = pd.read_csv('stock_sentiment_train_sample (1).csv')\n",
+    "df = df[['text','label']]\n",
+    "label_map = {2:'increase', 1:'neutral', 0:'decrease'}\n",
+    "df['label_name'] = df['label'].map(label_map)\n",
+    "df.head()\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "X_train, X_test, y_train, y_test = train_test_split(df[\"text\"], df[\"label_name\"], test_size=0.2, random_state=42, stratify=df[\"label_name\"])\n",
+    "vectorizer = TfidfVectorizer(stop_words=\"english\", max_features=5000)\n",
+    "X_train_vec = vectorizer.fit_transform(X_train)\n",
+    "X_test_vec = vectorizer.transform(X_test)\n",
+    "clf = LogisticRegression(max_iter=1000)\n",
+    "clf.fit(X_train_vec, y_train)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "pred = clf.predict(X_test_vec)\n",
+    "print(classification_report(y_test, pred))\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def predict_movement(text):\n",
+    "    vec = vectorizer.transform([text])\n",
+    "    return clf.predict(vec)[0]\n",
+    "\n",
+    "sample_tweets = [\n",
+    "    \"Tesla is going to the moon!\",\n",
+    "    \"I think the market looks shaky.\",\n",
+    "    \"Stock trading will remain flat today.\"\n",
+    "]\n",
+    "for tw in sample_tweets:\n",
+    "    print(tw, \"->\", predict_movement(tw))\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ]
 }


### PR DESCRIPTION
## Summary
- simplify `trump_prediction_sentiment.ipynb`
- train TF‑IDF/Logistic Regression model on sample stock sentiment data
- provide helper to predict whether a tweet implies an **increase**, **decrease**, or **neutral** price movement

## Testing
- `python3` snippet executed to train and evaluate the model

------
https://chatgpt.com/codex/tasks/task_e_6874125e4864832b9e0401ae7169a6c1